### PR TITLE
Merge branch 'main' into feature-batching, because the BatchRenderer is complete

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -31,7 +31,7 @@ int main (int argc, char *argv[])
 
     glewInit();
 
-    Scene::Batching activeScene;
+    Scene::Verlet activeScene;
     activeScene.Start();
 
     double lastTime = glfwGetTime();


### PR DESCRIPTION
batching works now. The batchrenderer is treated as a single mesh object which must apply a single shader to all it's constituent objects